### PR TITLE
Refactor Check with log instead of Panic

### DIFF
--- a/util/battery_utility.go
+++ b/util/battery_utility.go
@@ -152,7 +152,7 @@ func InputByteArrayToInt(s string) int {
 /*
 * Since time Duration is in nanoseconds, we need to work in nanoseconds
 * to calculate the discharge ratio.
-* d in this function is the discharge percentage, h time duration in nanoseconds
+* d is discharge percentage, h time duration in nanoseconds
  */
 func CalculateDischargeRatePerHour(d int, h time.Duration) float32 {
 	return float32(d) * 3600000000000 / float32(h)

--- a/util/check.go
+++ b/util/check.go
@@ -1,7 +1,11 @@
 package util
 
+import (
+	"log"
+)
+
 func Check(e error) {
 	if e != nil {
-		panic(e)
+		log.Fatal(e)
 	}
 }


### PR DESCRIPTION
Due to power_now no available on all systems, changed Panic for Log.Fatal so the output message is less "violent" for the user.