### PR TITLE
Add util.Check(err) after unused err variables

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -51,6 +51,7 @@ func Insert(charge int, timestamp time.Time) {
 	util.Check(err)
 
 	id, err := res.LastInsertId()
+	util.Check(err)
 
 	fmt.Printf("created timestamp (%d) %d%% at %s\n", id, charge, util.ParseTime(timestamp))
 }
@@ -134,6 +135,7 @@ func SaveLastPeriod() {
 	util.Check(err)
 
 	id, err := res.LastInsertId()
+	util.Check(err)
 
 	fmt.Printf("Saved (%d) %d%% elapsed: %v dr: %0.3fWh\n", id, period.Discharge, period.DischargeTime, period.DischargeRatio)
 }


### PR DESCRIPTION
An assignment is ineffectual if the variable assigned is not thereafter used.