### PR TITLE
Remove fmt.Fprintln to avoid duplicate error output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,17 +1,14 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{Use: "gobatmon"}
 
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+	err := rootCmd.Execute()
+	if err != nil {
+		return
 	}
 }


### PR DESCRIPTION
See (https://github.com/spf13/cobra/issues/1415)